### PR TITLE
Expand on contract compiler compatibility comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,12 +202,41 @@ We provide four example `docker-compose.<...>.yml` files to demonstrate the four
 
 Timber relies on being 'fed' details about the contracts it should subscribe to. When we POST to the `/start` endpoint of Timber, it will search for contract details at the `CONTRACT_ORIGIN` location we have specified.
 
-Importantly, Timber can only interpret smart contract interface json files which have been compiled with `solc`.
+Importantly, Timber expects smart contract interface json filesin `/app/build/contracts` to have the following format:
+```
+{
+  abi: "...",
+  evm:
+    bytecode:
+      object: "0x..."
+}
+```  
+
+`0x/sol-compiler` outputs JSON in this format:
+```
+{
+  compiledOutput:
+    abi: "...",
+    evm:
+      bytecode: 
+        object: "0x..."
+}
+```
+
+`truffle compile` outputs JSON in this format:
+```
+{
+  abi: "...",
+  bytecode: "0x...."
+}
+```
+
+Timber uses the `abi` field but does not currently use `bytecode`, so truffle's format works without any translation.
 
 We use the `CONTRACT_ORIGIN` environment variable to specify one of four options:
 
 ##### `default`
-Timber will look for solc-compiled contract interface json files in `/app/build/`. You'll need to mount the relevant interface json files to this location.
+Timber will look for solc-compiled contract interface json files in `/app/build/contracts`. You'll need to mount the relevant interface json files to this location.
 
 ##### `remote`
 Timber will `GET` the solc-compiled contract interface json files from some external container. We call this external container 'deployer' (because, presumably it has deployed the contracts).
@@ -219,7 +248,7 @@ You will need to specify two extra environment variables:
 Timber will get the solc-compiled contract interface json files from a mongodb collection.
 
 ##### `compile`
-If no _solc_-compiled json files are available, then we'll need Timber to compile the contracts itself (using solc) from solidity files. You'll need to mount the relevant solidity files (including dependencies) to `app/contracts/`. Timber will then compile the `.sol` files itself, and store the contract interface json files in `app/build/`.
+If no _solc_-compiled json files are available, then we'll need Timber to compile the contracts itself (using solc) from solidity files. You'll need to mount the relevant solidity files (including dependencies) to `app/contracts/`. Timber will then compile the `.sol` files itself, and store the contract interface json files in `app/build/contracts`.
 
 #### `HASH_TYPE`
 

--- a/merkle-tree/config/default.js
+++ b/merkle-tree/config/default.js
@@ -69,7 +69,7 @@ module.exports = {
   # Specify one of:
   # - 'remote' (to GET them from a remote microservice); or
   # - 'mongodb' (to get them from mongodb); or
-  # - 'compile' (to compile the contracts from /app/build to /app/contracts)
+  # - 'compile' (to compile the contracts from /app/build to /app/build/contracts)
   # - 'default' (to get them from the /app/build/contracts folder)
   */
   contractOrigin: process.env.CONTRACT_ORIGIN,


### PR DESCRIPTION
The current top-level README makes a statement that the `merkle-tree` service only works with `solc` compiler. I don't think this is completely accurate so added some further content on compiler compatibility.