### PR TITLE
fix: updateNodes now accepts integer values

### DIFF
--- a/merkle-tree/src/utils-merkle-tree.js
+++ b/merkle-tree/src/utils-merkle-tree.js
@@ -178,9 +178,13 @@ async function updateNodes(leafValues, currentLeafCount, frontier, height, updat
     leafIndex++
   ) {
     nodeValueFull = leafValues[leafIndex - currentLeafCount];
-    // console.log('nodeValueFull:', nodeValueFull, 'hashlength:', config.NODE_HASHLENGTH);
+    console.log('nodeValueFull:', nodeValueFull, 'hashlength:', config.NODE_HASHLENGTH);
+    if (!utils.isHex(nodeValueFull)) {
+      nodeValueFull = utils.convertBase(nodeValueFull.toString(), 10, 16);
+      console.log('nodeValueFull:', nodeValueFull, 'hashlength:', config.NODE_HASHLENGTH);
+    }
     nodeValue = `0x${nodeValueFull.slice(-config.NODE_HASHLENGTH * 2)}`; // truncate hashed value, so it 'fits' into the next hash.
-    // console.log('nodeValue:', nodeValue);
+    console.log('nodeValue:', nodeValue);
     nodeIndex = leafIndexToNodeIndex(leafIndex, height); // convert the leafIndex to a nodeIndex
 
     slot = getFrontierSlot(leafIndex); // determine at which level we will next need to store a nodeValue

--- a/merkle-tree/src/utils-merkle-tree.js
+++ b/merkle-tree/src/utils-merkle-tree.js
@@ -178,13 +178,13 @@ async function updateNodes(leafValues, currentLeafCount, frontier, height, updat
     leafIndex++
   ) {
     nodeValueFull = leafValues[leafIndex - currentLeafCount];
-    console.log('nodeValueFull:', nodeValueFull, 'hashlength:', config.NODE_HASHLENGTH);
+    // console.log('nodeValueFull:', nodeValueFull, 'hashlength:', config.NODE_HASHLENGTH);
     if (!utils.isHex(nodeValueFull)) {
       nodeValueFull = utils.convertBase(nodeValueFull.toString(), 10, 16);
-      console.log('nodeValueFull:', nodeValueFull, 'hashlength:', config.NODE_HASHLENGTH);
+      // console.log('nodeValueFull:', nodeValueFull, 'hashlength:', config.NODE_HASHLENGTH);
     }
     nodeValue = `0x${nodeValueFull.slice(-config.NODE_HASHLENGTH * 2)}`; // truncate hashed value, so it 'fits' into the next hash.
-    console.log('nodeValue:', nodeValue);
+    // console.log('nodeValue:', nodeValue);
     nodeIndex = leafIndexToNodeIndex(leafIndex, height); // convert the leafIndex to a nodeIndex
 
     slot = getFrontierSlot(leafIndex); // determine at which level we will next need to store a nodeValue

--- a/merkle-tree/src/utils.js
+++ b/merkle-tree/src/utils.js
@@ -34,6 +34,94 @@ const mimcCurves = {
   },
 };
 
+/** Helper function for the converting any base to any base
+ */
+function convertBase(str, fromBase, toBase) {
+  const digits = parseToDigitsArray(str, fromBase);
+  if (digits === null) return null;
+
+  let outArray = [];
+  let power = [1];
+  for (let i = 0; i < digits.length; i += 1) {
+    // invariant: at this point, fromBase^i = power
+    if (digits[i]) {
+      outArray = add(outArray, multiplyByNumber(digits[i], power, toBase), toBase);
+    }
+    power = multiplyByNumber(fromBase, power, toBase);
+  }
+
+  let out = '';
+  for (let i = outArray.length - 1; i >= 0; i -= 1) {
+    out += outArray[i].toString(toBase);
+  }
+  // if the original input was equivalent to zero, then 'out' will still be empty ''. Let's check for zero.
+  if (out === '') {
+    let sum = 0;
+    for (let i = 0; i < digits.length; i += 1) {
+      sum += digits[i];
+    }
+    if (sum === 0) out = '0';
+  }
+
+  return out;
+}
+
+function parseToDigitsArray(str, base) {
+  const digits = str.split('');
+  const ary = [];
+  for (let i = digits.length - 1; i >= 0; i -= 1) {
+    const n = parseInt(digits[i], base);
+    if (Number.isNaN(n)) return null;
+    ary.push(n);
+  }
+  return ary;
+}
+
+function add(x, y, base) {
+  const z = [];
+  const n = Math.max(x.length, y.length);
+  let carry = 0;
+  let i = 0;
+  while (i < n || carry) {
+    const xi = i < x.length ? x[i] : 0;
+    const yi = i < y.length ? y[i] : 0;
+    const zi = carry + xi + yi;
+    z.push(zi % base);
+    carry = Math.floor(zi / base);
+    i += 1;
+  }
+  return z;
+}
+
+/** Helper function for the converting any base to any base
+ Returns a*x, where x is an array of decimal digits and a is an ordinary
+ JavaScript number. base is the number base of the array x.
+ */
+function multiplyByNumber(num, x, base) {
+  if (num < 0) return null;
+  if (num === 0) return [];
+
+  let result = [];
+  let power = x;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    // eslint-disable-next-line no-bitwise
+    if (num & 1) {
+      result = add(result, power, base);
+    }
+    num >>= 1; // eslint-disable-line
+    if (num === 0) break;
+    power = add(power, power, base);
+  }
+  return result;
+}
+
+// Converts integer value strings to hex values
+function decToHex(decStr) {
+  const hex = ensure0x(convertBase(decStr, 10, 16));
+  return hex;
+}
+
 /**
 utility function to remove a leading 0x on a string representing a hex number.
 If no 0x is present then it returns the string un-altered.
@@ -57,6 +145,16 @@ function ensure0x(hex = '') {
     return `0x${hexString}`;
   }
   return hexString;
+}
+
+/**
+utility function to check that a string is hexadecimal
+*/
+function isHex(value) {
+  if (typeof value !== 'string') return false;
+  if (value.indexOf('0x') !== 0) return false;
+  const regexp = /^[0-9a-fA-F]+$/;
+  return regexp.test(strip0x(value));
 }
 
 /**
@@ -203,8 +301,11 @@ function concatenateThenHash(...items) {
 }
 
 export default {
+  convertBase,
+  decToHex,
   ensure0x,
   strip0x,
+  isHex,
   concatenate,
   mimcHash,
   shaHash,


### PR DESCRIPTION
## Fix: integer value leaves

Fixed a bug in which Timber expected all leaves from emitted events to be in hex form. Only presented itself when `updateNodes` was called.

Now, `updateNodes` checks whether the input leaf (here, `nodeValueFull`) is hex before truncating it. If it's not, it converts to hex using `convertBase`. We haven't noticed/needed a fix since most cases have leaves being emitted in 32 byte hex form, but now we have MiMC hashing over two curves using uints will be more common!

Tested with both Timber and external tests.