### PR TITLE
Timber startup scripts - remove Nodemon from npm start

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
   merkle-tree:
     build:
       context: ./merkle-tree
-      dockerfile: dev.Dockerfile
+      dockerfile: Dockerfile
     restart: on-failure
     depends_on:
       - ganache

--- a/merkle-tree/dev.Dockerfile
+++ b/merkle-tree/dev.Dockerfile
@@ -6,4 +6,4 @@ COPY ./package.json ./package-lock.json ./
 RUN npm ci
 
 EXPOSE 80
-CMD npm start
+CMD npm run dev

--- a/merkle-tree/package.json
+++ b/merkle-tree/package.json
@@ -4,7 +4,8 @@
   "description": "construct and store a merkle tree from its leaves",
   "main": "index.js",
   "scripts": {
-    "start": "nodemon --ignore /app/build/ --exec babel-node ./src/index.js",
+    "start": "babel-node ./src/index.js",
+    "dev": "nodemon --ignore /app/build/ --exec babel-node ./src/index.js",
     "test": "truffle test"
   },
   "author": "iAmMichaelConnor",

--- a/merkle-tree/src/middleware/assign-db-connection.js
+++ b/merkle-tree/src/middleware/assign-db-connection.js
@@ -10,12 +10,7 @@ export default async function(req, res, next) {
 
   try {
     let contractName = req.body.contractName;
-    if (contractName === 'MerkleTreeControllerMiMC') {
-      contractName =
-        process.env.CURVE === 'BLS12_377'
-          ? 'MerkleTreeControllerMiMC_BLS12'
-          : 'MerkleTreeControllerMiMC_BN254';
-    } else if (contractName === undefined) {
+    if (contractName === undefined) {
       const contractNameTest = req.body[0].contractName;
       if (contractNameTest === undefined) {
         throw new Error('No contractName key provided in req.body.');

--- a/merkle-tree/src/routes/merkle-tree.routes.js
+++ b/merkle-tree/src/routes/merkle-tree.routes.js
@@ -21,12 +21,6 @@ async function startEventFilter(req, res, next) {
   console.log('\nsrc/routes/merkle-tree.routes startEventFilter()');
 
   let contractName = req.body.contractName;
-  if (contractName === 'MerkleTreeControllerMiMC') {
-    contractName =
-      process.env.CURVE === 'BLS12_377'
-        ? 'MerkleTreeControllerMiMC_BLS12'
-        : 'MerkleTreeControllerMiMC_BN254';
-  }
   const treeId = req.body.treeId;
   const { db } = req.user;
   const { contractAddress } = req.body; // contractAddress is an optional parameter. Address can instead be inferred by Timber in many cases.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "main": "index.js",
   "scripts": {
-    "start": "nodemon --exec babel-node ./src/index.js",
+    "start": "babel-node ./src/index.js",
     "test": "truffle test"
   },
   "author": "iAmMichaelConnor",


### PR DESCRIPTION
### Startup

- Linked Dockerfile to `npm start`, which now uses only babel-node (not nodemon)
- Linked dev.Dockerfile to `npm run dev`, which uses nodemon

So, when using an image of timber, you can add `command: npm run dev` or `npm start` to override the above.

- Also removed hanging test code, closes #24 