### PR TITLE
GET calls can have data as query params

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,7 @@ For getting/inserting/updating information relating to leaves of the tree.
   - `/leaf/index/:leafIndex` Get a leaf by leafIndex  
   - `/leaf/index` Get a leaf by leafIndex  
   - `/leaf/value` Get a leaf by leafValue  
+  Note that the latter two are not restful endpoints and the leafIndex or the leafValue should be passed in as GET query parameters {contractName, value}
 - `POST`
   - **WARNING**: these POST requests were built for quick db testing only. In practice, insertions of leaves into Timber's merkle-tree db should only be done via the event subscriptions to MerkleTree smart contract(s). (See the `/start` endpoint for starting an event subscription).
   - `/leaf` Insert a leaf into the merkle-tree db.
@@ -427,14 +428,14 @@ For getting/inserting/updating information relating to leaves of the tree.
 #### `/leaves`
 - `GET`
   - `/leaves` Get information about multiple leaves at once.
-  There are several options, specified through the request body:
-    - `req.body: { "leafIndices": [10, 15, 100000, 10000000] }`
+  There are several options, specified through the request body (DEPRECATED) or via query parameters:
+    - `{ "leafIndices": [10, 15, 100000, 10000000] }`
       Specify a selection of leaves, by their leafIndices.
-    - `req.body: { "values": ["0x1234", "hello", "0x12345678"] }`
+    - `{ "values": ["0x1234", "hello", "0x12345678"] }`
       Specify a selection of leaves, by their values.
-    - `req.body: { "minIndex": 10, "maxIndex": 1000 }`
+    - `{ "minIndex": 10, "maxIndex": 1000 }`
       Specify a range of leaves, by the lower and upper bounds of the index range.
-    - `req.body: {}`
+    - `{}`
       Get information about all leaves.  
   - `/leaves/check` Run some broad checks on the leaves of the tree, to check for corrupted filtering, or leaf tracking.
   - `/leaves/count` Get the number of leaves currently in the merkle-tree mongodb.
@@ -459,14 +460,14 @@ For getting/inserting/updating information relating to nodes of the tree. A leaf
 #### `/nodes`
 - `GET`
   - `/nodes` Get information about multiple nodes at once.
-  There are several options, specified through the request body:
-    - `req.body: { "nodeIndices": [10, 15, 100000, 10000000] }`
+  There are several options, specified through the request body (DEPRECATED) or via query parameters:
+    - `{ "nodeIndices": [10, 15, 100000, 10000000] }`
       Specify a selection of nodes, by their nodeIndices (can include leaves).
-    - `req.body: { "values": ["0x1234", "hello", "0x12345678"] }`
+    - `{ "values": ["0x1234", "hello", "0x12345678"] }`
       Specify a selection of nodes, by their values  (can include leaves).
-    - `req.body: { "minIndex": 10, "maxIndex": 1000 }`
+    - `{ "minIndex": 10, "maxIndex": 1000 }`
       Specify a range of nodes, by the lower and upper bounds of the index range      (can include leaves).
-    - `req.body: {}`
+    - `{}`
       Get information about all nodes (includes leaves).
   - `/nodes/count` Get the number of nodes currently in the merkle-tree mongodb (includes leaves).
 - `POST`

--- a/merkle-tree/src/middleware/assign-db-connection.js
+++ b/merkle-tree/src/middleware/assign-db-connection.js
@@ -6,10 +6,10 @@ const { admin } = config.get('mongo');
 
 export default async function(req, res, next) {
   console.log('\nsrc/middleware/assign-db-connection');
-  // console.log('req.body:', req.body);
+  console.log('req.query, req.body:', req.query, req.body);
 
   try {
-    let { contractName } = req.body;
+    let contractName  = req.body.contractName || req.query.contractName;
     if (contractName === undefined) {
       const contractNameTest = req.body[0].contractName;
       if (contractNameTest === undefined) {
@@ -18,7 +18,7 @@ export default async function(req, res, next) {
         contractName = contractNameTest;
       }
     }
-    const { treeId } = req.body;
+    const treeId = req.body.treeId || req.query.treeId;
     // console.log(`treeId: ${treeId}`);
     req.user = {};
     // give all requesters admin privileges:

--- a/merkle-tree/src/routes/leaf.routes.js
+++ b/merkle-tree/src/routes/leaf.routes.js
@@ -54,7 +54,7 @@ async function getLeafByLeafIndex(req, res, next) {
   console.log('req.body:');
   console.log(req.body);
   try {
-    const leafIndex = req.params.leafIndex || req.body.leafIndex;
+    const leafIndex = req.params.leafIndex || req.body.leafIndex || req.body.leafIndex;
     const leafService = new LeafService(req.user.db);
     res.data = await leafService.getLeafByLeafIndex(leafIndex);
     next();
@@ -77,7 +77,7 @@ async function getLeafByValue(req, res, next) {
   console.log('req.body:');
   console.log(req.body);
   try {
-    const { value } = req.body;
+    const  value  = req.body.value || req.query.value;
     const leafService = new LeafService(req.user.db);
     res.data = await leafService.getLeafByValue(value);
     next();
@@ -102,8 +102,13 @@ async function getLeaves(req, res, next) {
   console.log(req.body);
   try {
     const leafService = new LeafService(req.user.db);
+    // some clients call get with data in the body.  That's naughty but we handle it anyway
+    const leafIndices = req.body.leafIndices || req.query.leafIndices;
+    const values = req.body.values || req.query.values;
+    const minIndex = req.body.minIndex || req.query.minIndex;
+    const maxIndex = req.body.maxIndex || req.query.maxIndex;
 
-    const { leafIndices, values, minIndex, maxIndex } = req.body; // necessarily, not all of these destructurings will be possible
+    // not necessarily, not all of these destructurings will be possible
     console.log('leafIndices:', leafIndices);
     console.log('values:', values);
     console.log('minIndex:', minIndex);
@@ -189,7 +194,7 @@ async function countLeaves(req, res, next) {
 
   try {
     const leafService = new LeafService(req.user.db);
-    const leafCount = await leafService.countLeaves(req.body);
+    const leafCount = await leafService.countLeaves(req.body); // TODO - no need to send req.body??
     res.data = { leafCount };
     next();
   } catch (err) {

--- a/merkle-tree/src/routes/leaf.routes.js
+++ b/merkle-tree/src/routes/leaf.routes.js
@@ -194,7 +194,7 @@ async function countLeaves(req, res, next) {
 
   try {
     const leafService = new LeafService(req.user.db);
-    const leafCount = await leafService.countLeaves(req.body); // TODO - no need to send req.body??
+    const leafCount = await leafService.countLeaves();
     res.data = { leafCount };
     next();
   } catch (err) {

--- a/merkle-tree/src/routes/node.routes.js
+++ b/merkle-tree/src/routes/node.routes.js
@@ -56,7 +56,7 @@ async function getNodeByNodeIndex(req, res, next) {
  */
 async function getNodeByValue(req, res, next) {
   try {
-    const { value } = req.body;
+    const value = req.body.value || req.query.value;
     const nodeService = new NodeService(req.user.db);
     res.data = await nodeService.getNodeByValue(value);
     next();
@@ -92,7 +92,11 @@ async function getNodes(req, res, next) {
   try {
     const nodeService = new NodeService(req.user.db);
 
-    const { nodeIndices, values, minIndex, maxIndex } = req.body; // necessarily, not all of these deconstructions will be possible
+    const nodeIndices = req.body.nodeIndices || req.query.nodeIndices;
+    const values = req.body.values || req.query.values;
+    const minIndex = req.body.minIndex || req.query.minIndex;
+    const maxIndex = req.body.maxIndex || req.query.maxIndex;
+    // necessarily, not all of these deconstructions will be possible
 
     if (nodeIndices) {
       res.data = await nodeService.getNodesByNodeIndices(nodeIndices);


### PR DESCRIPTION
Timber expects GET requests, with accompanying data, to place that data in the request body.  This is not really a supported http approach and some http clients will fail to package data in this way.
This fix adds the option to pass data as GET query parameters.  The code checks to see if the required data was passed in the body or as a query and thus is backwards compatible.