### PR TITLE
feat: testnet support

### DIFF
--- a/merkle-tree/config/default.js
+++ b/merkle-tree/config/default.js
@@ -142,9 +142,10 @@ module.exports = {
   mongo: {
     host: 'mongo-merkle-tree',
     port: '27017',
-    databaseName: 'merkle_tree',
+    databaseName: process.env.DB_NAME || 'merkle_tree',
     admin: 'admin',
     adminPassword: 'admin',
+    dbUrl: process.env.DB_URL || 'mongodb://mongo-merkle-tree:27017',
   },
   isLoggerEnabled: true,
 
@@ -152,7 +153,7 @@ module.exports = {
   web3: {
     host: process.env.BLOCKCHAIN_HOST,
     port: process.env.BLOCKCHAIN_PORT,
-
+    rpcUrl: process.env.RPC_URL,
     options: {
       defaultAccount: '0x0',
       defaultBlock: '0', // e.g. the genesis block our blockchain

--- a/merkle-tree/src/db/common/adminDbConnection.js
+++ b/merkle-tree/src/db/common/adminDbConnection.js
@@ -1,10 +1,13 @@
 import mongoose from 'mongoose';
 import config from 'config';
 
-const { host, port, databaseName } = config.get('mongo');
+const { host, port, databaseName, dbUrl } = config.get('mongo');
 const dbConnections = {};
+let url;
+if (dbUrl) url = dbUrl;
+else url = `${host}:${port}`;
 
-dbConnections.admin = mongoose.createConnection(`mongodb://${host}:${port}/${databaseName}`, {
+dbConnections.admin = mongoose.createConnection(`${url}/${databaseName}`, {
   useNewUrlParser: true,
   useCreateIndex: true,
 });

--- a/merkle-tree/src/utils-web3.js
+++ b/merkle-tree/src/utils-web3.js
@@ -44,6 +44,11 @@ async function getBlockTransactionCount(blockHashOrBlockNumber) {
   return blockTxCount;
 }
 
+async function getTransactionReceipt(transactionHash) {
+  const receipt = await web3.eth.getTransactionReceipt(transactionHash);
+  return receipt;
+}
+
 /**
 Returns a block matching the block number or block hash.
 @param {String|Number} hashStringOrNumber A block number or hash. Or the string "genesis", "latest" or "pending" as in the default block parameter.
@@ -89,6 +94,23 @@ async function getContractAddress(contractName) {
   logger.silly(`deployed address: ${deployedAddress}`);
 
   return deployedAddress;
+}
+
+async function getDeployedContractTransactionHash(contractName) {
+  logger.debug(`./src/utils-web3 getDeployedContractTransactionHash(${contractName})`);
+  let transactionHash;
+  const contractInterface = getContractInterface(contractName);
+
+  const networkId = await web3.eth.net.getId();
+  logger.silly(`networkId: ${networkId}`);
+
+  if (contractInterface && contractInterface.networks && contractInterface.networks[networkId]) {
+    transactionHash = contractInterface.networks[networkId].transactionHash;
+  }
+
+  logger.silly(`deployed transactionHash: ${transactionHash}`);
+
+  return transactionHash;
 }
 
 // returns a web3 contract instance (as opposed to a truffle-contract instance)
@@ -266,4 +288,6 @@ export default {
   getContractBytecode,
   subscribeToEvent,
   unsubscribe,
+  getDeployedContractTransactionHash,
+  getTransactionReceipt,
 };

--- a/merkle-tree/src/web3.js
+++ b/merkle-tree/src/web3.js
@@ -12,7 +12,10 @@ export default {
   connection() {
     return this.web3;
   },
-
+  buildUrl() {
+    if (config.web3.rpcUrl) return config.web3.rpcUrl;
+    else return `${config.web3.host}:${config.web3.port}`;
+  },
   /**
    * Connects to web3 and then sets proper handlers for events
    */
@@ -21,7 +24,7 @@ export default {
 
     logger.info('Blockchain Connecting ...');
     const provider = new Web3.providers.WebsocketProvider(
-      `${config.web3.host}:${config.web3.port}`,
+      this.buildUrl(),
       null,
       config.web3.options,
     );


### PR DESCRIPTION
Support for RPC url apart from blockchain host and port. 
For testnet and mainnet set the initial blockNumber for filtering events to the blockNumber of Shield contract deployment transaction.