### PR TITLE
mongo connection url corrected

### DIFF
--- a/merkle-tree/src/db/common/adminDbConnection.js
+++ b/merkle-tree/src/db/common/adminDbConnection.js
@@ -5,7 +5,7 @@ const { host, port, databaseName, dbUrl } = config.get('mongo');
 const dbConnections = {};
 let url;
 if (dbUrl) url = dbUrl;
-else url = `${host}:${port}`;
+else url = `mongodb://${host}:${port}`;
 
 dbConnections.admin = mongoose.createConnection(`${url}/${databaseName}`, {
   useNewUrlParser: true,


### PR DESCRIPTION
this PR fixes a small bug, prefix `mongodb://` mongodb protocol to connection url
this bug appeared in `nightfall-client`