### PR TITLE
add new replayEvent endpoint for L2 sync

### DIFF
--- a/merkle-tree/src/auto-start.js
+++ b/merkle-tree/src/auto-start.js
@@ -19,7 +19,7 @@ const autoStart = async () => {
     // Timber has the ability to infer one. Otherwise Timber will fall over. If
     // the build artefacts don't exist yet then we need to wait.
     // Stop eslint complaining because we DO want delays in this loop
-    let retries = process.env.AUTOSTART_RETRIES || 20;
+    let retries = process.env.AUTOSTART_RETRIES || 50;
     while (!data.contractAddress) {
       try {
         // eslint-disable-next-line no-await-in-loop

--- a/merkle-tree/src/filter-controller.js
+++ b/merkle-tree/src/filter-controller.js
@@ -198,7 +198,7 @@ Naming convention:
   eventName: eventNameResponseFunction
 }
 */
-const responseFunctions = {
+export const responseFunctions = {
   NewLeaf: newLeafResponseFunction,
   NewLeaves: newLeavesResponseFunction,
   Rollback: rollbackResponseFunction,


### PR DESCRIPTION
This PR adds a new endpoint `/replayEvent` that passes events received (from `optimist`) onto the relevant event-handlers.

This needs similar named PRs in `deployer` and `optimist`.