### PR TITLE
More testnet capabilities & mongo user management

### DIFF
--- a/merkle-tree/src/db/common/adminDbConnection.js
+++ b/merkle-tree/src/db/common/adminDbConnection.js
@@ -10,6 +10,11 @@ else url = `mongodb://${host}:${port}`;
 dbConnections.admin = mongoose.createConnection(`${url}/${databaseName}`, {
   useNewUrlParser: true,
   useCreateIndex: true,
+  authSource: "admin",
+  user: "admin",
+  pass: "admin",
+  useUnifiedTopology: true,
+  useFindAndModify: false 
 });
 
 const adminDbConnection = dbConnections.admin;

--- a/merkle-tree/src/utils-web3.js
+++ b/merkle-tree/src/utils-web3.js
@@ -207,17 +207,9 @@ async function subscribeToEvent(
     signature: '0x881cc8af0159324ccea314ad98a0cf26fe0e460c2afa693c92f591613d4de7b2' }
   */
 
-
-  // changed below for sepolia ws url - NOT TESTED ON ANY OTHER BLOCKCHAIN
-  
-  // const eventJsonInterface = web3.utils._.find(
-  //   contractInstance._jsonInterface, // eslint-disable-line no-underscore-dangle
-  //   o => o.name === eventName && o.type === 'event',
-  // );
-
   const eventJsonInterface = contractInstance._jsonInterface.find(o => o.name === eventName && o.type === 'event');
 
-  logger.info(`eventJsonInterface: ${JSON.stringify(eventJsonInterface, null, 2)}`);
+  logger.silly(`eventJsonInterface: ${JSON.stringify(eventJsonInterface, null, 2)}`);
 
   const eventSubscription = await contractInstance.events[eventName]({
     fromBlock,

--- a/merkle-tree/src/utils-web3.js
+++ b/merkle-tree/src/utils-web3.js
@@ -206,12 +206,18 @@ async function subscribeToEvent(
     type: 'event',
     signature: '0x881cc8af0159324ccea314ad98a0cf26fe0e460c2afa693c92f591613d4de7b2' }
   */
-  const eventJsonInterface = web3.utils._.find(
-    contractInstance._jsonInterface, // eslint-disable-line no-underscore-dangle
-    o => o.name === eventName && o.type === 'event',
-  );
 
-  logger.silly(`eventJsonInterface: ${JSON.stringify(eventJsonInterface, null, 2)}`);
+
+  // changed below for sepolia ws url - NOT TESTED ON ANY OTHER BLOCKCHAIN
+  
+  // const eventJsonInterface = web3.utils._.find(
+  //   contractInstance._jsonInterface, // eslint-disable-line no-underscore-dangle
+  //   o => o.name === eventName && o.type === 'event',
+  // );
+
+  const eventJsonInterface = contractInstance._jsonInterface.find(o => o.name === eventName && o.type === 'event');
+
+  logger.info(`eventJsonInterface: ${JSON.stringify(eventJsonInterface, null, 2)}`);
 
   const eventSubscription = await contractInstance.events[eventName]({
     fromBlock,


### PR DESCRIPTION
Made some small changes after suggestions from OCM and Starlight:

- Now searches for event interface via the contract's `JSON` file rather than web3 - this fixes usage with some testnets as the `web3._` lib is outdated
- Adds admin details to the mongo connection - it seems like there is no way outside of the timber image to actually set these details and allow timber to write/update the db correctly