### PR TITLE
fix: http cache semantics package vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7087,9 +7087,9 @@
       "dev": true
     },
     "http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "http-errors": {
       "version": "2.0.0",


### PR DESCRIPTION
### Related Ticket
https://eyblockchain.atlassian.net/browse/TAX-4412

#### Dependent PR's
No dependent PRs

### Description
Updated the package `http-cache-semantics` to fix warning issues.

### Checklist

<!-- Go over the checklist, and put an `x` in all the boxes when you confirm they've been done. -->

- [x] I have tested the endpoints of the basic nightfall operations `withdraw`, `transfer`, and `deposit`.
- [x] I have run a full-ZKP Dividend Event.
- [x] If there are any `TODOs` or `FIXME`, they are left as `TODO|FIXME: <description>`
- [x] I have removed unused code (e.g., console.logs, commented out blocks, etc.)
- [x] Execute functionality locally, add screenshot evidence to the PR
- [x] The branch name is related to the ticket. <username>/<ticket-number>-<branch-name>
- [x] Include a link to the PR of the JIRA ticket in the description
- [x] Include a brief description of the changes (at least 2 lines). Include any dependent changes
      in the description.
- [x] Rebase and leave a single commit

### Evidence
![image](https://user-images.githubusercontent.com/81176116/218839245-a2b35eee-0a6e-47fb-ac0a-1502c8440200.png)

