### PR TITLE
Jfsanchocr/fix execution of mend report

### DIFF
--- a/.github/workflows/taxgrid-v22_mend.yml
+++ b/.github/workflows/taxgrid-v22_mend.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: '16.16.0'
 
       - name: Install Modules
-        run:
+        run: |
             cd /home/runner/work/timber/timber/merkle-tree
             npm install
         env:  


### PR DESCRIPTION

Change where the command 'npm install' is going to be executed for the mend report GitHub action