### PR TITLE
fix: group count and max leaf into one call to fix cast error

### DIFF
--- a/merkle-tree/src/db/mongodb/db.js
+++ b/merkle-tree/src/db/mongodb/db.js
@@ -230,7 +230,7 @@ export default class DB {
       const count = await Model.countDocuments(query);
 
       logger.debug('src/db/mongodb/db countDocuments()');
-      logger.silly(`count ${JSON.stringify(count, null, 2)}`);
+      logger.silly(`src/db/mongodb/db count ${JSON.stringify(count, null, 2)}`);
 
       return Promise.resolve(count);
     } catch (e) {

--- a/merkle-tree/src/db/service/leaf.service.js
+++ b/merkle-tree/src/db/service/leaf.service.js
@@ -245,6 +245,25 @@ export default class LeafService {
     return leafIndex;
   }
 
+  async getCountAndMaxLeafIndex()  {
+    logger.debug('src/db/service/leaf.service getCountAndMaxLeafIndex()');
+
+    const docs = await this.db.getDocs(
+      COLLECTIONS.NODE,
+      { leafIndex: { $exists: true } },    // query
+      { leafIndex: 1, _id: 0 },            // projection (output only these keys)
+      { leafIndex: -1 },                   // sort by leafIndex in descending order (we'll then grab the top one)
+    );
+     
+    const { leafIndex } = docs[0] || {}; // this should give you the 'top' document
+    const leafCount = docs.length;
+
+    return {
+      maxLeafIndex: leafIndex,
+      leafCount
+    }
+  }
+
   async findMissingLeaves(startLeafIndex, endLeafIndex) {
     logger.debug('src/db/service/leaf.service findMissingLeaves()');
 


### PR DESCRIPTION
Add a default value to the assignation of minMissingLeafIndex in case missingLeaves array is empty.

Group the 2 calls made in checkLeaves method to get the count and max of leaves in one call instead of two.