### PR TITLE
Manoj/oss fixes

### DIFF
--- a/merkle-tree/package-lock.json
+++ b/merkle-tree/package-lock.json
@@ -3935,7 +3935,9 @@
       "license": "MIT"
     },
     "node_modules/config": {
-      "version": "3.3.9",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/config/-/config-3.3.12.tgz",
+      "integrity": "sha512-Vmx389R/QVM3foxqBzXO8t2tUikYZP64Q6vQxGrsMpREeJc/aWRnPRERXWsYzOHAumx/AOoILWe6nU3ZJL+6Sw==",
       "license": "MIT",
       "dependencies": {
         "json5": "^2.2.3"


### PR DESCRIPTION
1. Fix `config` package error like below:
(node:94) [DEP0044] DeprecationWarning: The `util.isArray` API is deprecated. Please use `Array.isArray()` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
(node:94) [DEP0055] DeprecationWarning: The `util.isRegExp` API is deprecated. Please use `arg instanceof RegExp` instead.
(node:94) [DEP0047] DeprecationWarning: The `util.isDate` API is deprecated.  Please use `arg instanceof Date` instead.