### PR TITLE
fix: enable redis connection based on env variable

### DIFF
--- a/merkle-tree/src/bem/infra/redis/redis-client.js
+++ b/merkle-tree/src/bem/infra/redis/redis-client.js
@@ -6,6 +6,9 @@ const APP_PREFIX = (process.env.REDIS_ENV_PREFIX || '') + 'timber:';
 
 export function createRedisClient() {
     try {
+        if(!process.env.ENABLE_BLOCKCHAIN_EVENT_MANAGER && !process.env.REDIS_HOST)
+            return true;
+
         const redisConfig = {
             host: process.env.REDIS_HOST,
             port: process.env.REDIS_PORT,


### PR DESCRIPTION
Enable redis connection based on env variable `ENABLE_BLOCKCHAIN_EVENT_MANAGER` which prevents redis connection error as part of backward compatibility